### PR TITLE
Tf Best Practices: fixed no-commit-to-branch hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,8 +26,7 @@ repos:
     - id: check-vcs-permalinks
     - id: forbid-new-submodules
     - id: no-commit-to-branch
-      args:
-        - "--branch=main"
+      args: ['--branch', 'master']
 
     # Common errors
     - id: end-of-file-fixer


### PR DESCRIPTION
@ctreatma This fixes a small bug with the [no-commit-to-branch](https://github.com/pre-commit/pre-commit-hooks#no-commit-to-branch) hook where it would error out after merge. See https://github.com/equinix-labs/terraform-equinix-template/actions/runs/4285862297