### PR TITLE
Changed the generate-release CI job to only be triggered manually

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,20 +4,11 @@ name: generate-release
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths:
-      - '**/*.tpl'
-      - '**/*.tf'
-      - '.github/workflows/release.yml'
 
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    # Skip running release workflow on forks
-    #if: github.repository_owner == 'terraform-equinix-template'
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR contains the following changes:
- Changed the generate-release CI job to only be triggered manually