### PR TITLE
fix: use amd64 arch in action-install-gh-release pre-commit.yaml

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -67,6 +67,6 @@ jobs:
       with:
         repo: aquasecurity/tfsec
         platform: linux
-        arch: x86-64
+        arch: amd64
 
     - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
Fix the architecture (`s/x86-/amd/`) per action-install-gh-release upstream maintainer comment:
https://github.com/jaxxstorm/action-install-gh-release/issues/52#issuecomment-1877963785

Blocks #14 